### PR TITLE
Some proptests and a Benchee-based benchmark

### DIFF
--- a/benchmarks/simple.exs
+++ b/benchmarks/simple.exs
@@ -1,4 +1,5 @@
 require Modulo
+require Integer
 
 dividends = StreamData.integer()
 divisors  = StreamData.integer() |> StreamData.filter(&(&1 != 0))
@@ -7,10 +8,13 @@ args =
 
 Benchee.run(
   %{
-    "Modulo.mod (body)" => fn input ->
+    "mod (non-guard)" => fn input ->
       Enum.map(input, fn {a, b}  -> Modulo.mod(a, b) end)
     end,
-    "Modulo.mod (guard)" => fn input ->
+    "mod (unoptimized guard)" => fn input ->
+      Enum.map(input, fn {a, b}  -> Modulo.unoptimized_guard_safe_mod(a, b) end)
+    end,
+    "mod (optimized guard)" => fn input ->
       Enum.map(input, fn {a, b}  -> Modulo.guard_safe_mod(a, b) end)
     end,
     "rem" => fn input ->

--- a/benchmarks/simple.exs
+++ b/benchmarks/simple.exs
@@ -18,11 +18,14 @@ Benchee.run(
     end
   },
   time: 5,
-  formatters: [{Benchee.Formatters.Console, extended_statistics: true}],
+  formatters: [
+    Benchee.Formatters.HTML,
+    {Benchee.Formatters.Console, extended_statistics: true}
+  ],
   inputs: %{
     "1" => Enum.take(args, 1),
     "100" => Enum.take(args, 100),
-    "1_000" => Enum.take(args, 1_000),
-    "10_000" => Enum.take(args, 10_000),
+    "1000" => Enum.take(args, 1_000),
+    "10000" => Enum.take(args, 10_000),
   }
 )

--- a/benchmarks/simple.exs
+++ b/benchmarks/simple.exs
@@ -4,21 +4,25 @@ dividends = StreamData.integer()
 divisors  = StreamData.integer() |> StreamData.filter(&(&1 != 0))
 args =
   Stream.zip(dividends, divisors)
-  |> Stream.take(1_000)
-  |> Enum.to_list
 
 Benchee.run(
   %{
-    "Modulo.mod (body)" => fn ->
-      Enum.map(args, fn {a, b}  -> Modulo.mod(a, b) end)
+    "Modulo.mod (body)" => fn input ->
+      Enum.map(input, fn {a, b}  -> Modulo.mod(a, b) end)
     end,
-    "Modulo.mod (guard)" => fn ->
-      Enum.map(args, fn {a, b}  -> Modulo.guard_safe_mod(a, b) end)
+    "Modulo.mod (guard)" => fn input ->
+      Enum.map(input, fn {a, b}  -> Modulo.guard_safe_mod(a, b) end)
     end,
-    "rem" => fn ->
-      Enum.map(args, fn {a, b} -> rem(a, b) end)
+    "rem" => fn input ->
+      Enum.map(input, fn {a, b} -> rem(a, b) end)
     end
   },
-  time: 10,
+  time: 5,
   formatters: [{Benchee.Formatters.Console, extended_statistics: true}],
+  inputs: %{
+    "1" => Enum.take(args, 1),
+    "100" => Enum.take(args, 100),
+    "1_000" => Enum.take(args, 1_000),
+    "10_000" => Enum.take(args, 10_000),
+  }
 )

--- a/benchmarks/simple.exs
+++ b/benchmarks/simple.exs
@@ -1,0 +1,24 @@
+require Modulo
+
+dividends = StreamData.integer()
+divisors  = StreamData.integer() |> StreamData.filter(&(&1 != 0))
+args =
+  Stream.zip(dividends, divisors)
+  |> Stream.take(1_000)
+  |> Enum.to_list
+
+Benchee.run(
+  %{
+    "Modulo.mod (body)" => fn ->
+      Enum.map(args, fn {a, b}  -> Modulo.mod(a, b) end)
+    end,
+    "Modulo.mod (guard)" => fn ->
+      Enum.map(args, fn {a, b}  -> Modulo.guard_safe_mod(a, b) end)
+    end,
+    "rem" => fn ->
+      Enum.map(args, fn {a, b} -> rem(a, b) end)
+    end
+  },
+  time: 10,
+  formatters: [{Benchee.Formatters.Console, extended_statistics: true}],
+)

--- a/lib/modulo.ex
+++ b/lib/modulo.ex
@@ -29,7 +29,15 @@ defmodule Modulo do
     IO.inspect(Macro.to_string(res))
     res
   end
-  
+
+  # Only exposed for the benchmark
+  @doc false
+  defmacro guard_safe_mod(dividend, divisor) do
+    quote do
+      unquote(dividend) - (unquote(divisor) * unquote(floor_div(dividend, divisor)))
+    end
+  end
+
   @doc """
   Computes the modulo remainder of an integer division.
 
@@ -57,9 +65,7 @@ defmodule Modulo do
     in_module? = (__CALLER__.context == nil)
     if not in_module? do
       # Guard-clause implementation
-      quote do
-        unquote(dividend) - (unquote(divisor) * unquote(floor_div(dividend, divisor)))
-      end
+      guard_safe_mod(dividend, divisor)
     else
       # Normal implementation
       quote do
@@ -73,4 +79,5 @@ defmodule Modulo do
       end
     end
   end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Modulo.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :stream_data]]
   end
 
   # Dependencies can be Hex packages:
@@ -27,6 +27,9 @@ defmodule Modulo.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [
+      {:benchee, "~> 1.0", only: :dev},
+      {:stream_data, "~> 0.5.0", only: [:dev, :test]}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule Modulo.Mixfile do
   defp deps do
     [
       {:benchee, "~> 1.0", only: :dev},
+      {:benchee_html, "~> 1.0", only: :dev},
       {:stream_data, "~> 0.5.0", only: [:dev, :test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
 %{
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "benchee_html": {:hex, :benchee_html, "1.0.0", "5b4d24effebd060f466fb460ec06576e7b34a00fc26b234fe4f12c4f05c95947", [:mix], [{:benchee, ">= 0.99.0 and < 2.0.0", [hex: :benchee, repo: "hexpm", optional: false]}, {:benchee_json, "~> 1.0", [hex: :benchee_json, repo: "hexpm", optional: false]}], "hexpm", "5280af9aac432ff5ca4216d03e8a93f32209510e925b60e7f27c33796f69e699"},
+  "benchee_json": {:hex, :benchee_json, "1.0.0", "cc661f4454d5995c08fe10dd1f2f72f229c8f0fb1c96f6b327a8c8fc96a91fe5", [:mix], [{:benchee, ">= 0.99.0 and < 2.0.0", [hex: :benchee, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "da05d813f9123505f870344d68fb7c86a4f0f9074df7d7b7e2bb011a63ec231c"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }

--- a/test/modulo_test.exs
+++ b/test/modulo_test.exs
@@ -1,8 +1,37 @@
 defmodule ModuloTest do
   use ExUnit.Case
+  use ExUnitProperties
   doctest Modulo
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  property "works for all numbers, has sign of divisor" do
+    check all dividend <- StreamData.integer(),
+              divisor <- StreamData.integer(),
+              divisor != 0,
+              dividend != divisor
+      do
+      res = Modulo.mod(dividend, divisor)
+      if res != 0 do
+        assert sign(res) == sign(divisor)
+      end
+    end
+  end
+
+  defp sign(0), do: 0
+  defp sign(x) when x > 0, do: 1
+  defp sign(x) when x < 0, do: -1
+
+  property "same output for positive numbers as `Kernel.rem/2`" do
+    check all a <- StreamData.positive_integer(),
+      b <- StreamData.positive_integer() do
+      assert Modulo.mod(a, b) === rem(a, b)
+    end
+  end
+
+  property "Raises for 0 divisor" do
+    check all dividend <- StreamData.integer() do
+      assert_raise ArithmeticError, fn ->
+        Modulo.mod(dividend, 0)
+      end
+    end
   end
 end


### PR DESCRIPTION
The output of the benchmark seems sort of promising:

The guard-safe implementation is only ~3 times slower than the non-guard-safe implementation for `Integer.mod`.